### PR TITLE
Add custom eval function

### DIFF
--- a/aiai/examples/example_custom_eval.py
+++ b/aiai/examples/example_custom_eval.py
@@ -5,21 +5,22 @@ This file demonstrates how to create a custom evaluation function for the aiai C
 The file should contain a function named 'main' that takes agent output as input
 and returns a dictionary with a 'reward' key.
 """
+
 import random
 
 
 def main(agent_output):
     """
     Custom evaluation function that scores agent output.
-    
+
     Args:
         agent_output: The output from the agent to evaluate
-        
+
     Returns:
         A dictionary with a 'reward' key containing a float from 0 to 1
     """
     score = 0.0
-    
+
     score += random.uniform(0, 1)
 
     return {"reward": score}

--- a/aiai/examples/example_custom_eval.py
+++ b/aiai/examples/example_custom_eval.py
@@ -1,0 +1,25 @@
+"""
+Example custom evaluation function.
+
+This file demonstrates how to create a custom evaluation function for the aiai CLI.
+The file should contain a function named 'main' that takes agent output as input
+and returns a dictionary with a 'reward' key.
+"""
+import random
+
+
+def main(agent_output):
+    """
+    Custom evaluation function that scores agent output.
+    
+    Args:
+        agent_output: The output from the agent to evaluate
+        
+    Returns:
+        A dictionary with a 'reward' key containing a float from 0 to 1
+    """
+    score = 0.0
+    
+    score += random.uniform(0, 1)
+
+    return {"reward": score}

--- a/aiai/main.py
+++ b/aiai/main.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from textwrap import dedent
 from time import monotonic
-from typing import cast, Callable, Optional
+from typing import Callable, Optional, cast
 
 import rich
 import typer
@@ -222,7 +222,7 @@ def main(
     concurrency: int = 16,
 ):  # noqa: C901 – the CLI can be a bit long
     """Interactive `aiai` CLI as described in `aiai/cli/README.md`.
-    
+
     You can provide custom data with --data and a custom evaluation function with --custom-eval-file.
     The custom evaluation file should contain an 'main' function that takes agent output and returns a reward dict.
     """
@@ -330,23 +330,23 @@ def main(
     # ------------------------------------------------------------------
     rules_eval = None
     custom_eval_fn = None
-    
+
     try:
         if custom_eval_file and custom_eval_file.exists():
             typer.echo(f"Using custom evaluation file: {custom_eval_file}")
             # Import the custom evaluation module
             import importlib.util
             import sys
-            
+
             module_name = custom_eval_file.stem
             spec = importlib.util.spec_from_file_location(module_name, custom_eval_file)
             if spec is None or spec.loader is None:
                 raise ImportError(f"Could not load custom eval file: {custom_eval_file}")
-                
+
             custom_eval_module = importlib.util.module_from_spec(spec)
             sys.modules[module_name] = custom_eval_module
             spec.loader.exec_module(custom_eval_module)
-            
+
             # Check if the module has a main function
             if hasattr(custom_eval_module, "main"):
                 custom_eval_fn = custom_eval_module.main
@@ -369,7 +369,7 @@ def main(
         )
         rules_eval = None
         custom_eval_fn = None
-        
+
     # ------------------------------------------------------------------
     # 6️⃣  Optimization run
     # ------------------------------------------------------------------

--- a/aiai/runner/py_script_tracer.py
+++ b/aiai/runner/py_script_tracer.py
@@ -3,7 +3,7 @@ import inspect
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 import openlit
 from opentelemetry import trace
@@ -52,7 +52,7 @@ class PyScriptTracer:
             del sys.modules[self.module_name]
         self.provider.force_flush()
 
-    def __call__(self, input_data=None, span_decorator: Callable[[Any], dict] | None = None) -> tuple[str, Any]:
+    def __call__(self, input_data=None, span_decorator: Optional[Callable[[Any], dict]] = None) -> tuple[str, Any]:
         with self.tracer.start_as_current_span("script_execution") as span:
             span.set_attribute("file_path", str(self.file_path))
 

--- a/aiai/test_main.py
+++ b/aiai/test_main.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import tempfile
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -97,3 +99,75 @@ def test_cli_demo_agent_success(
     mock_eval_perform.assert_called_once()
     mock_optimization_run.assert_called_once()
     mock_reset_db.assert_called_once()
+
+
+@pytest.mark.django_db
+@patch("aiai.main.typer.prompt")
+@patch("aiai.main._validate_entrypoint")
+@patch("aiai.main.analyze_code")
+@patch("aiai.main._optimization_run")
+@patch("aiai.main.reset_db")
+@patch("aiai.main.load_dotenv")
+@patch.object(sys, "argv", ["aiai", "--custom-eval-file", "test_eval.py"])
+def test_cli_with_custom_eval_file(
+    mock_load_dotenv,
+    mock_reset_db,
+    mock_optimization_run,
+    mock_analyze_code,
+    mock_validate_entrypoint,
+    mock_prompt,
+    capsys,
+):
+    """Test the path using a custom evaluation file."""
+    # Create a temporary file with a valid custom eval function
+    with tempfile.NamedTemporaryFile(suffix=".py", mode="w") as temp_file:
+        temp_file.write("""
+def main(agent_output):
+    return {"reward": 0.75}
+        """)
+        temp_file.flush()
+
+        custom_eval_path = Path(temp_file.name)
+
+        # Simulate user choosing '2' for custom agent
+        mock_prompt.return_value = 2
+        # Second prompt is for the entrypoint path
+        mock_prompt.side_effect = [2, str(custom_eval_path)]
+
+        # Mock core functions
+        mock_validate_entrypoint.return_value = None
+        mock_analyze_code.return_value = AgentContext(
+            "",
+            AgentAnalysis(
+                what="",
+                how="",
+                success_modes=[],
+                failure_modes=[],
+                expert_persona="",
+                considerations=[],
+            ),
+            OptimizerPrompts(
+                synthetic_data="",
+                reward_reasoning="",
+                traces_to_patterns="",
+                patterns_to_insights="",
+                insights_to_rules="",
+                synthesize_rules="",
+                rule_merger="",
+            ),
+        )
+
+        # Act - invoke CLI with custom eval file
+        result = runner.invoke(cli, ["--custom-eval-file", str(custom_eval_path)])
+
+        # Assert
+        assert result.exit_code == 0, f"CLI exited with code {result.exit_code}\nOutput:\n{result.output}"
+        assert "Using custom evaluation file" in result.output
+        assert "Custom evaluation function 'main' loaded successfully" in result.output
+
+        # Verify optimization was run with the custom eval function
+        mock_optimization_run.assert_called_once()
+        # Get the custom_eval_fn that was passed to _optimization_run
+        args, kwargs = mock_optimization_run.call_args
+        assert "custom_eval_fn" in kwargs
+        assert kwargs["custom_eval_fn"] is not None

--- a/aiai/test_main.py
+++ b/aiai/test_main.py
@@ -171,3 +171,100 @@ def main(agent_output):
         args, kwargs = mock_optimization_run.call_args
         assert "custom_eval_fn" in kwargs
         assert kwargs["custom_eval_fn"] is not None
+
+
+@pytest.mark.django_db
+@patch("aiai.main.typer.prompt")
+@patch("aiai.main._validate_entrypoint")
+@patch("aiai.main.analyze_code")
+@patch("aiai.main.reset_db")
+@patch("aiai.main.load_dotenv")
+@patch("aiai.main.generate_data")
+def test_custom_eval_function_is_automatically_executed(
+    mock_generate_data,
+    mock_load_dotenv,
+    mock_reset_db,
+    mock_analyze_code,
+    mock_validate_entrypoint,
+    mock_prompt,
+    monkeypatch,
+):
+    """Test that verifies the custom evaluation function is automatically executed during the optimization process."""
+    # Create a temporary custom eval file
+    with tempfile.NamedTemporaryFile(suffix=".py", mode="w") as temp_file:
+        temp_file.write("""
+def main(agent_output):
+    # This function will be called during the BatchRunner execution
+    with open('eval_was_executed.txt', 'w') as f:
+        f.write('Custom eval function was executed!')
+    return {"reward": 0.75}
+        """)
+        temp_file.flush()
+
+        # Setup test environment
+        custom_eval_path = Path(temp_file.name)
+        entrypoint_path = Path(__file__).parent.parent / "examples" / "crewai_agent.py"
+
+        # Generate mock data
+        mock_data = ["Test input 1", "Test input 2"]
+        mock_generate_data.return_value = [MagicMock(input_data=d) for d in mock_data]
+
+        # Mock user input
+        mock_prompt.side_effect = [2, str(entrypoint_path)]
+
+        # Mock validation and analysis
+        mock_validate_entrypoint.return_value = None
+        mock_analyze_code.return_value = AgentContext(
+            "",
+            AgentAnalysis(
+                what="Test agent", how="", success_modes=[], failure_modes=[], expert_persona="", considerations=[]
+            ),
+            OptimizerPrompts(
+                synthetic_data="",
+                reward_reasoning="",
+                traces_to_patterns="",
+                patterns_to_insights="",
+                insights_to_rules="",
+                synthesize_rules="",
+                rule_merger="",
+            ),
+        )
+
+        # Patch PyScriptTracer to return mock outputs without running actual scripts
+        def mock_tracer_call(self, input_data=None, **kwargs):
+            return "mock_trace_id", f"Output for {input_data}"
+
+        # Replace the real BatchRunner.perform with our own implementation
+        __import__("aiai.runner.batch_runner").runner.batch_runner.BatchRunner.perform
+
+        def mock_batch_runner_perform(self):
+            # Actually call the eval function with test output
+            eval_results = []
+            for data_item in self.data:
+                trace_id = "mock_trace_id"
+                output = f"Processed output for: {data_item}"
+                # This is the key part: actually calling the evaluation function
+                reward = self.eval(output)
+                from aiai.app.models import EvalRun
+
+                eval_results.append(EvalRun(trace_id=trace_id, input_data=data_item, output_data=output, reward=reward))
+            return eval_results
+
+        # Apply our patches
+        with patch("aiai.runner.py_script_tracer.PyScriptTracer.__call__", mock_tracer_call):
+            monkeypatch.setattr("aiai.runner.batch_runner.BatchRunner.perform", mock_batch_runner_perform)
+
+            # Clean up any previous test file
+            if Path("eval_was_executed.txt").exists():
+                Path("eval_was_executed.txt").unlink()
+
+            # Run the CLI with our custom eval file
+            runner.invoke(cli, ["--custom-eval-file", str(custom_eval_path)])
+
+            # Verify the evaluation function was called by checking for the file
+            assert Path("eval_was_executed.txt").exists()
+            content = Path("eval_was_executed.txt").read_text()
+            assert content == "Custom eval function was executed!"
+
+            # Clean up
+            Path("eval_was_executed.txt").unlink()


### PR DESCRIPTION
This pull request introduces support for custom evaluation functions in the `aiai` CLI, allowing users to define their own evaluation logic. Key changes include updates to the CLI interface, the `_optimization_run` function, and the evaluation flow to accommodate custom evaluation files and functions.

### Custom Evaluation Support:

* Added an example custom evaluation function in `aiai/examples/example_custom_eval.py`, demonstrating how to create a function named `main` that evaluates agent output and returns a reward dictionary.
* Updated the `_optimization_run` function in `aiai/main.py` to accept an optional `custom_eval_fn` parameter and use it as the evaluator if provided. [[1]](diffhunk://#diff-d704731cf92ce10d36826e9f68a36e2f6db65942022c273a869bc658e1035d52L119-R127) [[2]](diffhunk://#diff-d704731cf92ce10d36826e9f68a36e2f6db65942022c273a869bc658e1035d52R146-R155)
* Enhanced the `main` function in `aiai/main.py` to accept a `--custom-eval-file` argument, dynamically load the specified file, and validate the presence of a `main` function within it. [[1]](diffhunk://#diff-d704731cf92ce10d36826e9f68a36e2f6db65942022c273a869bc658e1035d52R219-R228) [[2]](diffhunk://#diff-d704731cf92ce10d36826e9f68a36e2f6db65942022c273a869bc658e1035d52L316-R359)

### Codebase Enhancements:

* Refactored type hints to use `Optional` for clarity and consistency in `aiai/main.py` and `aiai/runner/py_script_tracer.py`. [[1]](diffhunk://#diff-d704731cf92ce10d36826e9f68a36e2f6db65942022c273a869bc658e1035d52L9-R9) [[2]](diffhunk://#diff-c296f0cd95d840cc13a201b837259d45db3da52c3c48fe7f3c4557024488ac3fL6-R6) [[3]](diffhunk://#diff-c296f0cd95d840cc13a201b837259d45db3da52c3c48fe7f3c4557024488ac3fL55-R55)
* Updated the evaluation flow in `main` to handle both rule-based evaluation (`rules_eval`) and custom evaluation functions (`custom_eval_fn`). [[1]](diffhunk://#diff-d704731cf92ce10d36826e9f68a36e2f6db65942022c273a869bc658e1035d52R371-R376) [[2]](diffhunk://#diff-d704731cf92ce10d36826e9f68a36e2f6db65942022c273a869bc658e1035d52R388)