### PR TITLE
GitHub Actions workflow to automate the publishing of packages to PyPI

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,0 +1,41 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: eifinger/setup-rye@v3
+        id: setup-rye
+        with:
+          enable-cache: true
+          working-directory: py
+          cache-prefix: ${{ matrix.python-version }}
+      - name: Pin python-version ${{ matrix.python-version }}
+        working-directory: py
+        run: rye pin ${{ matrix.python-version }}
+      - name: Update Rye
+        run: rye self update
+      - name: Install dependencies
+        working-directory: py
+        run: rye sync --no-lock
+      - name: Run Tests
+        working-directory: py
+        run: rye run pytest -v
+      - name: Build package
+        working-directory: py
+        run: rye build
+      - name: Publish to PyPI
+        working-directory: py
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: rye publish --token $PYPI_TOKEN --yes --skip-existing


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the publishing of packages to PyPI. The workflow is triggered on release events and uses Rye for dependency management and package publishing.

### New GitHub Actions Workflow:

* `.github/workflows/pypi-release.yml`: Added a workflow named "Publish to PyPI" that:
  - Triggers on release events of type `published`.
  - Runs on `ubuntu-latest` with Python 3.11.
  - Includes steps to set up Rye, pin the Python version, update Rye, install dependencies, run tests, build the package, and publish it to PyPI using a secret token.