### PR TITLE
Fix pypi release workflow

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -18,24 +18,18 @@ jobs:
         id: setup-rye
         with:
           enable-cache: true
-          working-directory: py
           cache-prefix: ${{ matrix.python-version }}
       - name: Pin python-version ${{ matrix.python-version }}
-        working-directory: py
         run: rye pin ${{ matrix.python-version }}
       - name: Update Rye
         run: rye self update
       - name: Install dependencies
-        working-directory: py
         run: rye sync --no-lock
       - name: Run Tests
-        working-directory: py
         run: rye run pytest -v
       - name: Build package
-        working-directory: py
         run: rye build
       - name: Publish to PyPI
-        working-directory: py
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: rye publish --token $PYPI_TOKEN --yes --skip-existing


### PR DESCRIPTION
This pull request removes the `working-directory` key from several steps in the `.github/workflows/pypi-release.yml` file. The changes simplify the workflow configuration by eliminating redundant specifications.

Workflow configuration changes:

* Removed the `working-directory: py` key from multiple steps, including setup, pinning Python versions, updating Rye, installing dependencies, running tests, building the package, and publishing to PyPI. This change assumes the default working directory is sufficient for these steps.